### PR TITLE
Fix byte compile warning

### DIFF
--- a/ox-timeline.el
+++ b/ox-timeline.el
@@ -44,8 +44,6 @@
 (require 'ox-html)
 ;;; Code:
 
-(eval-when-compile (require 'cl))
-
 (org-export-define-derived-backend 'timeline 'html
   :menu-entry
   '(?T "Export to HTML Timeline"


### PR DESCRIPTION
It is not necessary to load cl.el. And cl.el is deprecated package and causes a byte-compile warning.

```
ox-timeline.el:47:30:Warning: Package cl is deprecated
```